### PR TITLE
Fix dependencies for 06/21

### DIFF
--- a/challenges/challenge-0/README.md
+++ b/challenges/challenge-0/README.md
@@ -120,7 +120,7 @@ Now switch to the `terraform` directory and initialize `terraform`:
 
 ```shell
 $ cd chaos-eng-workshop/terraform
-$ terraform init
+$ terraform init -upgrade
 
 Initializing modules...
 - common in common

--- a/terraform/common/main.tf
+++ b/terraform/common/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 2.6.0"
+  version = "~> 2.60.0"
   features {
   }
 }

--- a/terraform/data/main.tf
+++ b/terraform/data/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 2.6.0"
+  version = "~> 2.60.0"
   features {
   }
 }
@@ -102,7 +102,7 @@ resource "azurerm_cognitive_account" "textanalytics" {
   resource_group_name = var.resource_group_name
   kind                = "TextAnalytics"
 
-  sku_name = "S0"
+  sku_name = "F0"
 
   tags = {
     environment = var.env

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -113,4 +113,5 @@ output "nip_hostname" {
 
 output "ai_ik" {
     value = module.common.ai_instrumentation_key
+    sensitive = true
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 2.6.0"
+  version = "~> 2.60.0"
   features{
 
   }

--- a/terraform/messaging/main.tf
+++ b/terraform/messaging/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 2.6.0"
+  version = "~> 2.60.0"
   features {
   }
 }

--- a/terraform/storage/main.tf
+++ b/terraform/storage/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 2.6.0"
+  version = "~> 2.60.0"
   features {
   }
 }


### PR DESCRIPTION
Minor fixes to make instructions work in 06/21

- Updated azurerm version 2.6.0 -> 2.60.0
- Added sensitive flag to Azure AI Instrument Key
- Switched AI analytics to free Tier
- Updated Readme to include terraform upgrade command